### PR TITLE
Ability to use Scoped API Token rather than Global API Key

### DIFF
--- a/cloudflare-template.sh
+++ b/cloudflare-template.sh
@@ -58,8 +58,6 @@ fi
 ## Set the record identifier from result
 ###########################################
 record_identifier=$(echo "$record" | grep -Po '(?<="id":")[^"]*' | head -1)
-echo record! $record >> ~/log
-echo record ID! $record_identifier >> ~/log
 
 ###########################################
 ## Change the IP@Cloudflare using the API

--- a/cloudflare-template.sh
+++ b/cloudflare-template.sh
@@ -22,7 +22,7 @@ fi
 ## Check and set the proper auth header
 ###########################################
 if [ "${auth_method}" == "global" ]; then
-  auth_header="X-Auth-Email:"
+  auth_header="X-Auth-Key:"
 else
   auth_header="Authorization: Bearer"
 fi

--- a/cloudflare-template.sh
+++ b/cloudflare-template.sh
@@ -1,29 +1,41 @@
 #!/bin/bash
 
 auth_email=""                                      # The email used to login 'https://dash.cloudflare.com'
-auth_key=""                                        # Top right corner, "My profile" > "Global API Key"
+auth_method="token"                                # Set to "global" for Global API Key or "token" for Scoped API Token 
+auth_key=""                                        # Your API Token or Global API Key
 zone_identifier=""                                 # Can be found in the "Overview" tab of your domain
 record_name=""                                     # Which record you want to be synced
-proxy=true                                         # Set the proxy to true or false 
+proxy=false                                        # Set the proxy to true or false
+
 
 ###########################################
-## Check if we have an public IP
+## Check if we have a public IP
 ###########################################
 ip=$(curl -s https://api.ipify.org || curl -s https://ipv4.icanhazip.com/)
-if [ "${ip}" == "" ]; then 
+if [ "${ip}" == "" ]; then
   message="No public IP found."
   >&2 echo -e "${message}" >> ~/log
   exit 1
 fi
 
 ###########################################
+## Check and set the proper auth header
+###########################################
+if [ "${auth_method}" == "global" ]; then
+  auth_header="X-Auth-Email:"
+else
+  auth_header="Authorization: Bearer"
+fi
+
+###########################################
 ## Seek for the A record
 ###########################################
 echo " Check Initiated" >> ~/log
-record=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/$zone_identifier/dns_records?name=$record_name" -H "X-Auth-Email: $auth_email" -H "X-Auth-Key: $auth_key" -H "Content-Type: application/json")
+record=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/$zone_identifier/dns_records?name=$record_name" -H "X-Auth-Email: $auth_email" -H "$auth_header $auth_key" -H "Content-Type: application/json")
+
 
 ###########################################
-## Check if the domaine has an A record
+## Check if the domain has an A record
 ###########################################
 if [[ $record == *"\"count\":0"* ]]; then
   message=" Record does not exist, perhaps create one first? (${ip} for ${record_name})"
@@ -32,7 +44,7 @@ if [[ $record == *"\"count\":0"* ]]; then
 fi
 
 ###########################################
-## Get the existing IP 
+## Get existing IP
 ###########################################
 old_ip=$(echo "$record" | grep -Po '(?<="content":")[^"]*' | head -1)
 # Compare if they're the same
@@ -46,13 +58,15 @@ fi
 ## Set the record identifier from result
 ###########################################
 record_identifier=$(echo "$record" | grep -Po '(?<="id":")[^"]*' | head -1)
+echo record! $record >> ~/log
+echo record ID! $record_identifier >> ~/log
 
 ###########################################
 ## Change the IP@Cloudflare using the API
 ###########################################
 update=$(curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/$zone_identifier/dns_records/$record_identifier" \
                      -H "X-Auth-Email: $auth_email" \
-                     -H "X-Auth-Key: $auth_key" \
+                     -H "$auth_header $auth_key" \
                      -H "Content-Type: application/json" \
               --data "{\"id\":\"$zone_identifier\",\"type\":\"A\",\"proxied\":${proxy},\"name\":\"$record_name\",\"content\":\"$ip\"}")
 


### PR DESCRIPTION
To be able to use an API Token for DNS Zone edit only, a different header was needed to be sent to the API.
You can set auth_method to "global" to use the Global API Key like before, or "token" to use an API Token instead.
Using an API Token should be more secure than using the Global API Key.