### PR TITLE
Environment Input Variables with Validation

### DIFF
--- a/cloudflare-template.sh
+++ b/cloudflare-template.sh
@@ -1,13 +1,40 @@
 #!/bin/bash
+set -u
 
-auth_email=""                                      # The email used to login 'https://dash.cloudflare.com'
-auth_method="token"                                # Set to "global" for Global API Key or "token" for Scoped API Token 
-auth_key=""                                        # Your API Token or Global API Key
-zone_identifier=""                                 # Can be found in the "Overview" tab of your domain
-record_name=""                                     # Which record you want to be synced
-proxy=false                                        # Set the proxy to true or false
+auth_email="${DDNS_AUTH_EMAIL:-}"                  # The email used to login 'https://dash.cloudflare.com'
+auth_method="${DDNS_AUTH_METHOD:-token}"           # Set to "global" for Global API Key or "token" for Scoped API Token
+auth_key="${DDNS_AUTH_KEY:-}"                      # Your API Token or Global API Key
+zone_identifier="${DDNS_ZONE_IDENTIFIER:-}"        # Can be found in the "Overview" tab of your domain
+record_name="${DDNS_RECORD_NAME:-}"                # Which record you want to be synced
+proxy="${DDNS_PROXY:-false}"                       # Set the proxy to true or false
 
-
+###########################################
+## Validate variables have been set
+###########################################
+if [ -z "${auth_email}" ]; then
+  logger "DDNS Updater: DDNS_AUTH_EMAIL was unset"
+  exit 1
+fi
+if [ -z "${auth_method}" ]; then
+  logger "DDNS Updater: DDNS_AUTH_METHOD was unset"
+  exit 1
+fi
+if [ -z "${auth_key}" ]; then
+  logger "DDNS Updater: DDNS_AUTH_KEY was unset"
+  exit 1
+fi
+if [ -z "${zone_identifier}" ]; then
+  logger "DDNS Updater: DDNS_ZONE_IDENTIFIER was unset"
+  exit 1
+fi
+if [ -z "${record_name}" ]; then
+  logger "DDNS Updater: DDNS_RECORD_NAME was unset"
+  exit 1
+fi
+if [ -z "${proxy}" ]; then
+  logger "DDNS Updater: DDNS_PROXY was unset"
+  exit 1
+fi
 
 ###########################################
 ## Check if we have a public IP

--- a/cloudflare-template.sh
+++ b/cloudflare-template.sh
@@ -48,7 +48,7 @@ fi
 ###########################################
 old_ip=$(echo "$record" | grep -Po '(?<="content":")[^"]*' | head -1)
 # Compare if they're the same
-if [[ $ip == $old_ip ]]; then
+if [[ $ip == "${old_ip}" ]]; then
   logger "DDNS Updater: IP ($ip) for ${record_name} has not changed."
   exit 0
 fi


### PR DESCRIPTION
I noticed that to utilize the script, end-users have to actually edit its contents. It seemed to me that it would be more enabling to have input values passed in and validated when executed. This could enable potential "set-and-forget" workflows that "just work".

For example, one could clone the repo down and then the cronjob could not only execute the script but could also check to make sure the script was up to date first with a `git pull`. If the CloudFlare API were to introduce a breaking change, the script's code could be updated without most end-users even knowing about the change and experience little or no downtime thus providing higher availability to home setups.