### PR TITLE
replace PCRE regexp with standard regexp

### DIFF
--- a/cloudflare-template.sh
+++ b/cloudflare-template.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 auth_email=""                                      # The email used to login 'https://dash.cloudflare.com'
 auth_method="token"                                # Set to "global" for Global API Key or "token" for Scoped API Token 
@@ -46,7 +46,7 @@ fi
 ###########################################
 ## Get existing IP
 ###########################################
-old_ip=$(echo "$record" | grep -Po '(?<="content":")[^"]*' | head -1)
+old_ip=$(echo "$record" | sed -E 's/.*"content":"(([0-9]{1,3}\.){3}[0-9]{1,3})".*/\1/')
 # Compare if they're the same
 if [[ $ip == $old_ip ]]; then
   logger "DDNS Updater: IP ($ip) for ${record_name} has not changed."
@@ -56,7 +56,7 @@ fi
 ###########################################
 ## Set the record identifier from result
 ###########################################
-record_identifier=$(echo "$record" | grep -Po '(?<="id":")[^"]*' | head -1)
+record_identifier=$(echo "$record" | sed -E 's/.*"id":"(\w+)".*/\1/')
 
 ###########################################
 ## Change the IP@Cloudflare using the API


### PR DESCRIPTION
Hi!

I created this PR to permit running this nice script on e.g. OpenWRT, where the standard `grep` binary bundled-in is quite limited (it's actually `busybox`'s `grep`)
Please test it on your system, I think this way of doing things works correctly, but I might have missed something with double quotations for example. 

> Permits to run the script on simpler/lighter Linux distributions, e.g. OpenWRT, where the grep utility available does not permit to use Perl extended regexp (the `grep -P` option)