### PR TITLE
Update ip for existing record rather than creating a new one

### DIFF
--- a/cloudflare-template.sh
+++ b/cloudflare-template.sh
@@ -6,6 +6,7 @@ auth_method="token"                                # Set to "global" for Global 
 auth_key=""                                        # Your API Token or Global API Key
 zone_identifier=""                                 # Can be found in the "Overview" tab of your domain
 record_name=""                                     # Which record you want to be synced
+ttl="3600"                                         # Set the DNS TTL (seconds)
 proxy=false                                        # Set the proxy to true or false
 
 
@@ -62,11 +63,11 @@ record_identifier=$(echo "$record" | sed -E 's/.*"id":"(\w+)".*/\1/')
 ###########################################
 ## Change the IP@Cloudflare using the API
 ###########################################
-update=$(curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/$zone_identifier/dns_records/$record_identifier" \
+update=$(curl -s -X PATCH "https://api.cloudflare.com/client/v4/zones/$zone_identifier/dns_records/$record_identifier" \
                      -H "X-Auth-Email: $auth_email" \
                      -H "$auth_header $auth_key" \
                      -H "Content-Type: application/json" \
-              --data "{\"id\":\"$zone_identifier\",\"type\":\"A\",\"proxied\":${proxy},\"name\":\"$record_name\",\"content\":\"$ip\"}")
+                     --data "{\"type\":\"A\",\"name\":\"$record_name\",\"content\":\"$ip\",\"ttl\":\"$ttl\",\"proxied\":${proxy}}")
 
 ###########################################
 ## Report the status


### PR DESCRIPTION
Alright, this should fix issue #16. 

Okay, as specified [here](https://api.cloudflare.com/#dns-records-for-a-zone-patch-dns-record).

Cloudflare has two main methods to update an existing record.

- Update DNS Record ( PUT Method ), **creates new dns record** for an existing record

- PATCH DNS Record ( PATCH Method ), **modifies dns record** for an existing record

Changing from `PUT` to `PATCH` http method should do the job. Added an `ttl` just for convenience purposes.

Also, the **"id"** and **"zone_identifier"** is seemingly not longer needed in the data payload since they only require it inside the request query.

_PS: This is my first pull request, please be gentle xD_