### PR TITLE
Fix duplicate record and record being mysteriously deleted

### DIFF
--- a/cloudflare-template.sh
+++ b/cloudflare-template.sh
@@ -6,6 +6,7 @@ auth_method="token"                                # Set to "global" for Global 
 auth_key=""                                        # Your API Token or Global API Key
 zone_identifier=""                                 # Can be found in the "Overview" tab of your domain
 record_name=""                                     # Which record you want to be synced
+ttl="3600"                                         # Set the DNS TTL (seconds)
 proxy=false                                        # Set the proxy to true or false
 
 
@@ -34,7 +35,10 @@ fi
 ###########################################
 
 logger "DDNS Updater: Check Initiated"
-record=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/$zone_identifier/dns_records?name=$record_name" -H "X-Auth-Email: $auth_email" -H "$auth_header $auth_key" -H "Content-Type: application/json")
+record=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/$zone_identifier/dns_records?type=A&name=$record_name" \
+                      -H "X-Auth-Email: $auth_email" \
+                      -H "$auth_header $auth_key" \
+                      -H "Content-Type: application/json")
 
 ###########################################
 ## Check if the domain has an A record
@@ -62,11 +66,11 @@ record_identifier=$(echo "$record" | sed -E 's/.*"id":"(\w+)".*/\1/')
 ###########################################
 ## Change the IP@Cloudflare using the API
 ###########################################
-update=$(curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/$zone_identifier/dns_records/$record_identifier" \
+update=$(curl -s -X PATCH "https://api.cloudflare.com/client/v4/zones/$zone_identifier/dns_records/$record_identifier" \
                      -H "X-Auth-Email: $auth_email" \
                      -H "$auth_header $auth_key" \
                      -H "Content-Type: application/json" \
-              --data "{\"id\":\"$zone_identifier\",\"type\":\"A\",\"proxied\":${proxy},\"name\":\"$record_name\",\"content\":\"$ip\"}")
+              --data "{\"type\":\"A\",\"name\":\"$record_name\",\"content\":\"$ip\",\"ttl\":\"$ttl\",\"proxied\":${proxy}}")
 
 ###########################################
 ## Report the status


### PR DESCRIPTION
### Fixes issue #16, and this pull is also a rework of PR #19.
-----------      Description      -------------
Aha! Finally found the issue after looking carefully at Cloudflare audit logs.

At line 38, we must specify request query `type=A`. Which make sure the api only returns the record identifier for A record type.
Or else, the api will suppose we want a list of all matching record name with a **wildcard** record type.

For instance, let's say your domain 'example.org' has DNS records like this at Cloudflare.

| Record Type |   Record Name   |     Content     |
|-------------|:---------------:|:---------------:|
|      A      |   example.org   |    127.0.0.1    |
|    CNAME    | www.example.org |   example.org   |
|     CAA     |   example.org   | letsencrypt.org |
|     TXT     |   example.org   |   v=spf1 -all   |

If we try to fetch the details of a record name like `example.org` without specifying the `type` at request query.
Cloudflare will return us the details of `A, CAA, TXT` records. As long as the name requested matches the record name.

### So, what exactly happened?
Well it's hard to say. If given a list with mixed records, the regex `'s/.*"id":"(\w+)".*/\1/'` which extracts the record id from the api response, will sometimes extract the id of other records like `CAA` or `TXT` instead of `A`.

When irrelevant record id has been extracted, the entire record will be overwritten in the DDNS update step.
Like if `CAA` record id is matched, the record will be overwritten as the new `A` record with the current IP. Hence this is why records are being deleted out of nowhere and duplicate records are coming up.

Soooo, in order to avoid any conflicts, it's wiser to query A record only and match them.

#### Extra:

- Added ttl for convenience purposes
- Both `PUT` or `PATCH` request method will do the job fine, since issue #16 originated from where we are trying to get matching record identifier. But at cases like this, `PATCH` method is somewhat safer than `PUT`, so it's recommended to use it.