### PR TITLE
add support for generic GET webhook uri

### DIFF
--- a/cloudflare-template.sh
+++ b/cloudflare-template.sh
@@ -12,7 +12,19 @@ sitename=""                                         # Title of site "Example Sit
 slackchannel=""                                     # Slack Channel #example
 slackuri=""                                         # URI for Slack WebHook "https://hooks.slack.com/services/xxxxx"
 discorduri=""                                       # URI for Discord WebHook "https://discordapp.com/api/webhooks/xxxxx"
+healthchecksiouri=""                                # URI for healthchecks.io webhook (or any generic webhook to hit with a GET request)
 
+###########################################
+## Register a trap to hit the healthcheck endpoint when set
+###########################################
+do_healthcheck() {
+  RC=$?
+  # Only hit the healthcheck uri when we are going to exit status=0; else don't hit the endpoint, which will eventually cause an alarm
+  if [[ -n "$healthchecksiouri" && "$RC" == "0" ]]; then
+    curl -s -S -o /dev/null $healthchecksiouri
+  fi
+}
+trap do_healthcheck EXIT
 
 ###########################################
 ## Check if we have a public IP


### PR DESCRIPTION
Add ability to hit a generic webhook with a GET request on a successful run.  The idea here is to setup an endpoint on healthchecks.io, which will be hit on every successful run.  If the script fails, the webhook isn't hit, which eventually triggers an alarm on healthchecks.io.

Since this is just making a simple GET request, one could also use it to hit any generic webhook on success.