### PR TITLE
Removal of \w Shorthand in Favor of [A-Za-z0-9_] Character Range

### DIFF
--- a/cloudflare-template.sh
+++ b/cloudflare-template.sh
@@ -73,7 +73,7 @@ fi
 ###########################################
 ## Set the record identifier from result
 ###########################################
-record_identifier=$(echo "$record" | sed -E 's/.*"id":"(\w+)".*/\1/')
+record_identifier=$(echo "$record" | sed -E 's/.*"id":"([A-Za-z0-9_]+)".*/\1/')
 
 ###########################################
 ## Change the IP@Cloudflare using the API


### PR DESCRIPTION
This pull request contains a simple modification to the script to improve compatibility with systems that do not support the \w shorthand in Basic Regular Expressions (BRE). This change ensures consistent behavior across different environments by replacing the \w shorthand with the [A-Za-z0-9_] character range.

Changes Made:
Replaced all instances of \w with the [A-Za-z0-9_] character range.

Reason for the Change:
The \w shorthand, which represents word characters, is not universally supported, notably in the case of FreeBSD. This change ensures portability and maintains a consistent behavior across various systems. This modification will allow the script to function correctly on a wider range of platforms.