### PR TITLE
Change ttl from string to number

### DIFF
--- a/cloudflare-template.sh
+++ b/cloudflare-template.sh
@@ -6,7 +6,7 @@ auth_method="token"                                 # Set to "global" for Global
 auth_key=""                                         # Your API Token or Global API Key
 zone_identifier=""                                  # Can be found in the "Overview" tab of your domain
 record_name=""                                      # Which record you want to be synced
-ttl="3600"                                          # Set the DNS TTL (seconds)
+ttl=3600                                            # Set the DNS TTL (seconds)
 proxy="false"                                       # Set the proxy to true or false
 sitename=""                                         # Title of site "Example Site"
 slackchannel=""                                     # Slack Channel #example
@@ -82,7 +82,7 @@ update=$(curl -s -X PATCH "https://api.cloudflare.com/client/v4/zones/$zone_iden
                      -H "X-Auth-Email: $auth_email" \
                      -H "$auth_header $auth_key" \
                      -H "Content-Type: application/json" \
-                     --data "{\"type\":\"A\",\"name\":\"$record_name\",\"content\":\"$ip\",\"ttl\":\"$ttl\",\"proxied\":${proxy}}")
+                     --data "{\"type\":\"A\",\"name\":\"$record_name\",\"content\":\"$ip\",\"ttl\":$ttl,\"proxied\":${proxy}}")
 
 ###########################################
 ## Report the status

--- a/cloudflare-templatev6.sh
+++ b/cloudflare-templatev6.sh
@@ -18,7 +18,7 @@ zone_identifier=""
 # @proxy                - Set the proxy to true or false
 # -------------------------------------------------- #
 record_name=""
-ttl="3600"
+ttl=3600
 proxy="false"
 
 ###############  SCRIPT CONFIGURATION  ###############
@@ -143,7 +143,7 @@ update=$(curl -s -X PATCH "https://api.cloudflare.com/client/v4/zones/$zone_iden
     -H "X-Auth-Email: $auth_email" \
     -H "$auth_header $auth_key" \
     -H "Content-Type: application/json" \
-    --data "{\"content\":\"$ip\",\"ttl\":\"$ttl\",\"proxied\":$proxy}")
+    --data "{\"content\":\"$ip\",\"ttl\":$ttl,\"proxied\":$proxy}")
 
 ################################################
 ## Report the status


### PR DESCRIPTION
Cloudflare no longer accepts strings for ttl...

Error:
<13>Jun 5 17:42:30 root: {‘result’:null, ‘success’:false, ‘errors’:[{‘code’:9022, ‘message’: ‘TTL must be a number, not a string.’}], ‘messages’:[]}

Docs:
https://developers.cloudflare.com/api/operations/dns-records-for-a-zone-patch-dns-record