### PR TITLE
Always show status message when IP has not changed

### DIFF
--- a/cloudflare-template.sh
+++ b/cloudflare-template.sh
@@ -75,7 +75,7 @@ fi
 old_ip=$(echo "$record" | sed -E 's/.*"content":"(([0-9]{1,3}\.){3}[0-9]{1,3})".*/\1/')
 # Compare if they're the same
 if [[ $CURRENT_IP == $old_ip ]]; then
-  logger "DDNS Updater: IP ($CURRENT_IP) for ${record_name} has not changed."
+  logger -s "DDNS Updater: IP ($CURRENT_IP) for ${record_name} has not changed."
   exit 0
 fi
 


### PR DESCRIPTION
This PR helps users see a message for every run, even when no update was needed (e.g., in cron jobs).


Before : 
Jul 17 22:21:17 user: DDNS Updater: Fetched IP 0.0.0.0

After this PR :
Jul 17 22:21:17 user: DDNS Updater: Fetched IP 0.0.0.0
Jul 17 22:21:18 user: DDNS Updater: IP (0.0.0.0) for example.com has not changed.